### PR TITLE
Always check parameters order.

### DIFF
--- a/otx-suricata/suricata.py
+++ b/otx-suricata/suricata.py
@@ -29,7 +29,7 @@ class SuricataClient(object):
     def get_path(self, param):
         return os.path.join(self.base_dir, param)
 
-    def generate_rules(self, generate_md5_rules=False, generate_iprep=False):
+    def generate_rules(self, generate_iprep=False, generate_md5_rules=False):
         with self.get_destination('otx_file_rules.rules') as file_rule_file:
             with self.get_destination('reputation.list') as rep_file:
                 md5_file_count = 0


### PR DESCRIPTION
The order of parameters in 'generate_rules' functions was wrong. I don't understand how this has slipped through for all this time.